### PR TITLE
Minor Fixes for Build on Ubuntu 20.04 LTS

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -34,4 +34,7 @@ add_test(users_guide1       ${SVGEN_ROOT}/bin/test_svgen users_guide1)
 add_test(operand_mux        ${SVGEN_ROOT}/bin/test_svgen operand_mux)
 add_test(slide_example      ${SVGEN_ROOT}/bin/test_svgen slide_example)
 add_test(yuras_presentation ${SVGEN_ROOT}/bin/test_svgen yuras_presentation)
+#add_test(instr_pipe ${SVGEN_ROOT}/bin/test_svgen instr_pipe) # Disabled due to dependence on APLR_REPO
+#add_test(aplr ${SVGEN_ROOT}/bin/test_svgen aplr) # Disabled due to dependence on APLR_REPO
 #add_test(ring               ${SVGEN_ROOT}/bin/test_svgen test_vcs)
+#add_test(ring               ${SVGEN_ROOT}/bin/test_svgen ring) # Disabled due to usage of $ANY not supported on TLV 1a

--- a/src/tlv/behavioral/LogicalBehScope.java
+++ b/src/tlv/behavioral/LogicalBehScope.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
 import java.util.TreeMap;
 import java.util.Vector;
 
-import javax.xml.ws.handler.MessageContext.Scope;
+//import javax.xml.ws.handler.MessageContext.Scope;
 
 import tlv.Main;
 import tlv.behavioral.range.BitRange;


### PR DESCRIPTION
Minor Fix to build on Ubuntu 20.04 LTS.
Using Java Version:
```sh
$ java -version
openjdk version "11.0.11" 2021-04-20
OpenJDK Runtime Environment (build 11.0.11+9-Ubuntu-0ubuntu2.20.04)
OpenJDK 64-Bit Server VM (build 11.0.11+9-Ubuntu-0ubuntu2.20.04, mixed mode, sharing)
$ javac -version
javac 11.0.11
```